### PR TITLE
Contact Form: Use "Reply-To" instead of "From"

### DIFF
--- a/includes/ContactForm.php
+++ b/includes/ContactForm.php
@@ -122,7 +122,7 @@ class ContactForm {
         $subject = sanitize_text_field($this->options->accessibility_feedback_subject);
         $headers = [
             'Content-Type: text/plain; charset=UTF-8',
-            sprintf('From: %1$s <%2$s>', sanitize_text_field($name), sanitize_text_field($from))
+            sprintf('Reply-To: %1$s <%2$s>', sanitize_text_field($name), sanitize_text_field($from))
         ];
         if ($this->options->accessibility_feedback_cc) {
             $headers[] = sprintf('CC: <%s>', sanitize_email($this->options->accessibility_feedback_cc));


### PR DESCRIPTION
Setting the From-header to user-defined input is problematic with regard to DMARC/DKIM/SPF (especially for googlemail.com) or mistyped user input (non-existent domains). Then, mail servers may reject the email and we have a legal problem because the contact form doesn't work. As a solution, I propose to use the default wordpress sender, and put the user-specified address into Reply-To.